### PR TITLE
feat(rtc): idempotent POST /answer + preferredRegion (M2)

### DIFF
--- a/src/app/api/rtc/answer/route.ts
+++ b/src/app/api/rtc/answer/route.ts
@@ -1,55 +1,68 @@
-export const preferredRegion = ["fra1","iad1"];
-const __withNoStore = <T extends Response>(r:T):T => { try { (r as any).headers?.set?.("cache-control","no-store"); } catch {} return r; };
+export const preferredRegion = ["fra1", "iad1"];
+const __withNoStore = <T extends Response>(r: T): T => { try { (r as any).headers?.set?.("cache-control","no-store"); } catch {} return r; };
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-
-
-
-
-
-
 import { NextRequest, NextResponse } from "next/server";
 import { extractAnonId } from "@/lib/rtc/auth";
 import { get, setNxPx, expire } from "@/lib/rtc/upstash";
+import { createHash } from "node:crypto";
 
-function __noStore(res: any){ try{ res.headers?.set?.("Cache-Control","no-store"); }catch{} return res; }
-
+function __noStore(res: any) { try { res.headers?.set?.("Cache-Control","no-store"); } catch {} return res; }
 
 async function auth(anon: string, pairId: string) {
-  const map = await get(`rtc:pair:map:${anon}`); if (!map) return null;
+  const map = await get(`rtc:pair:map:${anon}`);
+  if (!map) return null;
   const [pid, role] = String(map).split("|");
   return pid === pairId ? role : null;
 }
 
+/**
+ * Idempotent POST /answer
+ * المفتاح: (pairId, role, sdpTag|fingerprint[, clientIdemKey]) مع TTL≈60s
+ * - أول طلب يمرّ: يكتب answer بقفل NX (120s)
+ * - التكرارات ضمن الـTTL تعيد 204 بلا تغيير حالة
+ */
 export async function POST(req: NextRequest) {
-  try {
-    const anon = extractAnonId(req); if (!anon) return __noStore(NextResponse.json({ error: "anon-required" }, { status: 403 }));
-    const { pairId, sdp } = await req.json().catch(() => ({}));
-    if (!pairId || !sdp) return __noStore(NextResponse.json({ error: "bad-input" }, { status: 400 }));
+  const anon = extractAnonId(req);
+  if (!anon) return __noStore(NextResponse.json({ error: "anon-required" }, { status: 403 }));
 
-    const role = await auth(anon, pairId);
-    if (role !== "callee") return __noStore(NextResponse.json({ error: "only-callee" }, { status: 403 }));
+  const { pairId, sdp } = await req.json().catch(() => ({} as any));
+  if (!pairId || !sdp) return __noStore(NextResponse.json({ error: "bad-input" }, { status: 400 }));
 
-    const sdpStr = typeof sdp === "string" ? sdp : JSON.stringify(sdp);
-    const ok = await setNxPx(`rtc:pair:${pairId}:answer`, sdpStr, 120_000);
-    if (!ok) return __noStore(NextResponse.json({ error: "exists" }, { status: 409 }));
+  const role = await auth(anon, pairId);
+  if (role !== "callee") return __noStore(NextResponse.json({ error: "only-callee" }, { status: 403 }));
 
-    await expire(`rtc:pair:${pairId}`, 150);
-    return __noStore(new NextResponse(null, { status: 204 }));
-  } catch (e: any) {
-    return __noStore(NextResponse.json({ error: "answer-fail", info: String(e?.message || e).slice(0, 140) }, { status: 500 }));
-  }
+  const h = req.headers;
+  const sdpTag = (h.get("x-sdp-tag") || "").trim() || null;
+  const clientKey = (h.get("x-idempotency-key") || "").trim() || null;
+  const fp = createHash("sha256").update(String(sdp)).digest("hex").slice(0, 16);
+
+  const idemKey = `rtc:idem:answer:${pairId}:${role}:${sdpTag || fp}:${clientKey || ""}`;
+  const isFirst = await setNxPx(idemKey, "1", 60_000); // TTL 60s
+  if (!isFirst) return __noStore(new NextResponse(null, { status: 204 }));
+
+  const ansKey = `rtc:pair:${pairId}:answer`;
+  const ok = await setNxPx(ansKey, String(sdp), 120_000);
+  if (!ok) return __noStore(NextResponse.json({ error: "exists" }, { status: 409 }));
+
+  await expire(`rtc:pair:${pairId}`, 150);
+  return __noStore(new NextResponse(null, { status: 204 }));
 }
 
 export async function GET(req: NextRequest) {
-  const anon = extractAnonId(req); if (!anon) return __noStore(NextResponse.json({ error: "anon-required" }, { status: 403 }));
+  const anon = extractAnonId(req);
+  if (!anon) return __noStore(NextResponse.json({ error: "anon-required" }, { status: 403 }));
+
   const pairId = String(new URL(req.url).searchParams.get("pairId") || "");
   if (!pairId) return __noStore(NextResponse.json({ error: "bad-input" }, { status: 400 }));
 
-  const role = await auth(anon, pairId); if (role !== "caller") return __noStore(NextResponse.json({ error: "only-caller" }, { status: 403 }));
-  const sdp = await get(`rtc:pair:${pairId}:answer`); if (!sdp) return __noStore(new NextResponse(null, { status: 204 }));
+  const role = await auth(anon, pairId);
+  if (role !== "caller") return __noStore(NextResponse.json({ error: "only-caller" }, { status: 403 }));
+
+  const sdp = await get(`rtc:pair:${pairId}:answer`);
+  if (!sdp) return __noStore(new NextResponse(null, { status: 204 }));
 
   await expire(`rtc:pair:${pairId}`, 150);
   return __noStore(NextResponse.json({ sdp: String(sdp) }, { status: 200 }));


### PR DESCRIPTION
Summary
- Add server idempotency for POST /api/rtc/answer
- Key = (pairId, role, sdpTag|fp[, clientIdemKey]), TTL≈60s
- First write uses NX; duplicates return 204 without state changes
- Keep GET semantics; add preferredRegion = ["fra1","iad1"]
- All responses set Cache-Control:no-store

Tech notes
- Uses upstash helpers: setNxPx/get/expire
- SHA256 fp for SDP when x-sdp-tag absent
- Role check: only callee may POST answer; only caller may GET

Acceptance
- Duplicate POST /answer → 204 within 60s window
- Legit conflicts → 409 "exists"
- GET /answer for caller returns {sdp}, else 204
- Headers echoed in responses; no-store present

Test steps
1) Deploy preview; open DevTools → Network
2) Send POST /api/rtc/answer twice with same pairId+sdpTag → 200/204
3) Poll GET /api/rtc/answer?pairId=… → 200 with sdp, then 204
4) Verify no 5xx in logs; preferredRegion applied

Rollout
- Merge after CI passes
- Monitor preview; then promote
- Rollback: revert PR (single-file change)
